### PR TITLE
adding session_duration variable and set to 2 hours default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,7 @@ module "bitbucket_service_provisioner" {
   oidc_subjects_with_wildcards = local.allowed_repository_uuids
   role_path = var.path
   allow_self_assume_role = var.allow_self_assume_role
+  max_session_duration = var.session_duration
 }
 
 #------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -79,3 +79,9 @@ variable "allow_self_assume_role" {
   default = true
   type = bool
 }
+
+variable "session_duration" {
+  type    = number
+  default = 7200
+  description = "The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of two hours is applied. This setting can have a value from 1 hour to 12 hours."
+}


### PR DESCRIPTION
This change makes the default session duration to 2 hours(previously it was set to 1hour)